### PR TITLE
Importing os to gaussians.py

### DIFF
--- a/src/gaussians.py
+++ b/src/gaussians.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import scipy.stats as ss
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Importing the os module to the [gaussians.py](https://github.com/UCB-stat-159-s21/Lab9/blob/main/src/gaussians.py) file, because it may be needed for managing paths.